### PR TITLE
fix qid bug

### DIFF
--- a/src/preret_csv.cpp
+++ b/src/preret_csv.cpp
@@ -75,9 +75,9 @@ int main(int argc, char **argv) {
         std::string buf_unigram, buf_bigram;
 
         // dump unigram features
-        buf_unigram = fgen_term_qry_main(termmap, qry.id, &stems[0], stems.size());
+        buf_unigram = fgen_term_qry_main(termmap, stoi(qry.id), &stems[0], stems.size());
         // dump bigram features
-        buf_bigram = fgen_bigram_qry_main(bigrammap, qry.id, &stems[0], stems.size());
+        buf_bigram = fgen_bigram_qry_main(bigrammap, stoi(qry.id), &stems[0], stems.size());
         std::string buf_common(buf_unigram);
         buf_common.append(buf_bigram);
 


### PR DESCRIPTION
When I downloaded and compile give the following bug:
text2feat/src/preret_csv.cpp:78:82: error: cannot convert ‘std::__cxx11::string {aka std::__cxx11::basic_string<char>}’ to ‘int’ for argument ‘2’ to ‘std::__cxx11::string fgen_term_qry_main(std::unordered_map<std::__cxx11::basic_string<char>, term_t>&, int, char**, size_t)’
        buf_unigram = fgen_term_qry_main(termmap, qry.id, &stems[0], stems.size());

Maybe qry.id should be converted to int first?